### PR TITLE
Correct Image Replacement: cid split onto new line

### DIFF
--- a/MHTMLParser.cs
+++ b/MHTMLParser.cs
@@ -297,7 +297,7 @@ public class MHTMLParser
                 {
                     if (strArray[0].Contains("image"))
                     {
-                        body = body.Replace("cid:" + strArray[1], "data:" + strArray[0] + ";base64," + strArray[2]);
+                        body = body.Replace("cid:" + System.Environment.NewLine, "cid:").Replace("cid:" + strArray[1], "data:" + strArray[0] + ";base64," + strArray[2]);
                         this.log += "Overwriting HTML with image: " + strArray[1] + "\n";
                     }
                 }


### PR DESCRIPTION
I ran into an issue with this, where the CID was split onto a second line. This fixed it.